### PR TITLE
Update Prowler report keys to ingest data to Security Hub

### DIFF
--- a/cloudformation-template/prowler-cloudformation-template.yml
+++ b/cloudformation-template/prowler-cloudformation-template.yml
@@ -136,7 +136,7 @@ Resources:
               accountId = os.environ['account_num']
               awsRegion = os.environ['region']
               # Use Prowler finding notes for ASFF Description
-              prowlerDescription = str(event['Records'][0]['dynamodb']['NewImage']['CHECK_RISK']['S'])
+              prowlerRiskDescription = str(event['Records'][0]['dynamodb']['NewImage']['CHECK_RISK']['S'])
               # Use Prowler finding title text for ASFF Title
               prowlerTitle = str(event['Records'][0]['dynamodb']['NewImage']['TITLE_TEXT']['S'])
               # looping through Prowler score result, set severity & compliance based on finding
@@ -184,7 +184,7 @@ Resources:
                                   'Normalized': prowlerProductNorm
                               },
                               'Title': prowlerTitle,
-                              'Description': prowlerDescription,
+                              'Description': prowlerRiskDescription,
                               'Resources': [
                                   {
                                       'Type': 'AwsAccount',

--- a/cloudformation-template/prowler-cloudformation-template.yml
+++ b/cloudformation-template/prowler-cloudformation-template.yml
@@ -136,11 +136,11 @@ Resources:
               accountId = os.environ['account_num']
               awsRegion = os.environ['region']
               # Use Prowler finding notes for ASFF Description
-              prowlerDescription = str(event['Records'][0]['dynamodb']['NewImage']['NOTES']['S'])
+              prowlerDescription = str(event['Records'][0]['dynamodb']['NewImage']['CHECK_RISK']['S'])
               # Use Prowler finding title text for ASFF Title
               prowlerTitle = str(event['Records'][0]['dynamodb']['NewImage']['TITLE_TEXT']['S'])
               # looping through Prowler score result, set severity & compliance based on finding
-              prowlerResult = str(event['Records'][0]['dynamodb']['NewImage']['RESULT']['S'])
+              prowlerResult = str(event['Records'][0]['dynamodb']['NewImage']['CHECK_RESULT']['S'])
               if prowlerResult == 'PASS':
                   prowlerComplianceRating = 'PASSED'
                   prowlerProductSev = int(0)

--- a/converter.py
+++ b/converter.py
@@ -23,8 +23,8 @@ with open('prowler_report.json') as f:
 # remove data not needed for Security Hub BatchImportFindings    
 for element in data: 
     del element['PROFILE']
-    del element['SCORED']
-    del element['LEVEL']
+    del element['ITEM_SCORED']
+    del element['ITEM_LEVEL']
     del element['ACCOUNT_NUM']
     del element['REGION']
 

--- a/converter.py
+++ b/converter.py
@@ -2,8 +2,8 @@ import csv
 import json
 
 # Set variables for within container
-CSV_PATH = 'prowler_report.csv'
-JSON_PATH = 'prowler_report.json'
+CSV_PATH = 'output/prowler_report.csv'
+JSON_PATH = 'output/prowler_report.json'
 
 # Reads prowler CSV output
 csv_file = csv.DictReader(open(CSV_PATH, 'r'))
@@ -17,7 +17,7 @@ for row in csv_file:
 open(JSON_PATH, 'w').write(json.dumps(json_list))
 
 # open newly converted prowler output
-with open('prowler_report.json') as f:
+with open('output/prowler_report.json') as f:
     data = json.load(f)
 
 # remove data not needed for Security Hub BatchImportFindings    
@@ -29,5 +29,5 @@ for element in data:
     del element['REGION']
 
 # writes out to a new file, prettified
-with open('format_prowler_report.json', 'w') as f:
+with open('output/format_prowler_report.json', 'w') as f:
     json.dump(data, f, indent=2)

--- a/loader.py
+++ b/loader.py
@@ -16,16 +16,19 @@ with open('output/format_prowler_report.json') as json_file:
     for finding in findings:
         TITLE_ID = finding['TITLE_ID']
         TITLE_TEXT = finding['TITLE_TEXT']
-        RESULT = finding['CHECK_RESULT']
+        CHECK_RESULT = finding['CHECK_RESULT']
         CHECK_RISK = finding['CHECK_RISK']
         CHECK_SEVERITY = finding['CHECK_SEVERITY']
+        CHECK_REMEDIATION = finding['CHECK_REMEDIATION']
 
-        print("Adding finding:", TITLE_ID, TITLE_TEXT, CHECK_RISK,CHECK_SEVERITY)
+        print("Adding finding:", TITLE_ID, TITLE_TEXT, CHECK_RESULT,CHECK_REMEDIATION,CHECK_RISK,CHECK_SEVERITY)
 
         table.put_item(
            Item={
                'TITLE_ID': TITLE_ID,
                'TITLE_TEXT': TITLE_TEXT,
+               'CHECK_RESULT': CHECK_RESULT,
+               'CHECK_REMEDIATION':CHECK_REMEDIATION,
                'CHECK_RISK': CHECK_RISK,
                'CHECK_SEVERITY': CHECK_SEVERITY,
             }

--- a/loader.py
+++ b/loader.py
@@ -11,21 +11,22 @@ dynamodb = boto3.resource('dynamodb', region_name=awsRegion)
 table = dynamodb.Table(prowlerDynamoDBTable)
 
 # CHANGE FILE AS NEEDED
-with open('format_prowler_report.json') as json_file:
+with open('output/format_prowler_report.json') as json_file:
     findings = json.load(json_file, parse_float = decimal.Decimal)
     for finding in findings:
         TITLE_ID = finding['TITLE_ID']
         TITLE_TEXT = finding['TITLE_TEXT']
-        RESULT = finding['RESULT']
-        NOTES = finding['NOTES']
+        RESULT = finding['CHECK_RESULT']
+        CHECK_RISK = finding['CHECK_RISK']
+        CHECK_SEVERITY = finding['CHECK_SEVERITY']
 
-        print("Adding finding:", TITLE_ID, TITLE_TEXT)
+        print("Adding finding:", TITLE_ID, TITLE_TEXT, CHECK_RISK,CHECK_SEVERITY)
 
         table.put_item(
            Item={
                'TITLE_ID': TITLE_ID,
                'TITLE_TEXT': TITLE_TEXT,
-               'RESULT': RESULT,
-               'NOTES': NOTES,
+               'CHECK_RISK': CHECK_RISK,
+               'CHECK_SEVERITY': CHECK_SEVERITY,
             }
         )

--- a/script.sh
+++ b/script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 echo "Running Prowler Scans"
-./prowler -b -n -f <REGION_TO_MODIFY> -g cislevel1 -M csv > prowler_report.csv
+./prowler -b -n -f <REGION_TO_MODIFY> -g cislevel1 -M csv -F
 echo "Converting Prowler Report from CSV to JSON"
 python converter.py
 echo "Loading JSON data into DynamoDB"


### PR DESCRIPTION
Fixed

- [x] `NOTES`, `RESULT`, `SCORED` and `LEVEL` no longer valid keys in Prowler's report.
- [x]  Added `-F` to generate a report `output/prowler_report.csv`
- [x]  Updated `loader.py` file with correct keys.

Initial Error:
<img width="598" alt="Screen Shot 2022-10-10 at 7 03 20 PM" src="https://user-images.githubusercontent.com/10117389/194971009-7adaa317-3ac1-401d-83d5-b43c12d72021.png">

Verified:
Items are present in DynamoDB table. 
<img width="645" alt="Screen Shot 2022-10-10 at 9 17 50 PM" src="https://user-images.githubusercontent.com/10117389/194982375-8e52597b-fbfd-470e-a929-d9d83c62cb84.png">

Data ingested into Security Hub
<img width="661" alt="Screen Shot 2022-10-10 at 11 10 41 PM" src="https://user-images.githubusercontent.com/10117389/194995322-307fef5b-a338-40ce-a504-0fdbb3fb9294.png">



